### PR TITLE
Clarify style of merge commit conflicts section

### DIFF
--- a/style/git/README.md
+++ b/style/git/README.md
@@ -79,7 +79,7 @@ into several makes more sense.
 ### Merge commits
 1. Subject kept as-is, even if it exceeds 50 characters
 2. Avoid merge conflicts whenever possible
-3. Conflicts section kept as-is
+3. Keep the "Conflicts:" listing by uncommenting it
 4. Avoid fast-forwards (use option `--no-ff` for `git merge`)
 5. Lists all commits merged (use option `--log=<n>` for `git merge` or set the
    `merge.log` config option)


### PR DESCRIPTION
New versions of Git remark the conflicts section by default; let's
clarify that we prefer it to be included in the commit message.
