### PR TITLE
Fix links in merge request document

### DIFF
--- a/process/merge_requests/README.md
+++ b/process/merge_requests/README.md
@@ -109,14 +109,14 @@ free to use the feature whenever applicable. To comment on a line, press the
 "Changes" tab near the top of the MR, then press a line number in one of the
 changed files to open up a comment box.
 
-Everywhere where you can leave a comment, [GitLab flavoured Markdown][1] is
+Everywhere where you can leave a comment, [GitLab flavoured Markdown][GFMD] is
 used. While it's helpful if you glance through the entire document, if you only
 take away one thing from it, it should be that you can turn any text into
 monospaced by surrounding it with backticks (or grave accents, as they're also
 called: `` ` ``). If you're talking about `SomeClass.with.some_method`, things
 become easier to if you surround it with backticks.
 
-  [1]: http://doc.gitlab.com/ce/markdown/markdown.html
+  [GFMD]: http://doc.gitlab.com/ce/markdown/markdown.html
 
 ### Closing a merge request
 When the reviewer considers the code ready to merge, he'll say so, and a label

--- a/process/merge_requests/README.md
+++ b/process/merge_requests/README.md
@@ -87,11 +87,11 @@ What does this mean?
 Let's say you've submitted your MR and the reviewer wants you to change
 something in a previous commit. If you previously had the habit of creating
 a commit, rebasing and squashing right away: refrain from doing so. The
-preferred way of doing things in this system [is to create fixup commits][1]
+preferred way of doing things in this system [is to create fixup commits][fixup]
 that are squashed at the very end of the life cycle of the MR, so pretty much
 when the reviewer approves the MR for merging.
 
-  [1]: http://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html
+  [fixup]: http://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html
 
 Basically, prefer not to rewrite history, until the MR is about to be merged.
 


### PR DESCRIPTION
The last two links in the document were pointing to the same URL due to me messing up the link naming in the markdown code.
